### PR TITLE
Remove an unnecessary assumption from unrest_pred not law.

### DIFF
--- a/utp_pred.thy
+++ b/utp_pred.thy
@@ -155,7 +155,7 @@ lemma unrest_pred [unrest]:
   "\<lbrakk> a \<sharp> P; a \<sharp> Q \<rbrakk> \<Longrightarrow> a \<sharp> P \<and> Q"
   "\<lbrakk> a \<sharp> P; a \<sharp> Q \<rbrakk> \<Longrightarrow> a \<sharp> P \<or> Q"
   "\<lbrakk> a \<sharp> P; a \<sharp> Q \<rbrakk> \<Longrightarrow> a \<sharp> P \<longrightarrow> Q"
-  "\<lbrakk> a \<sharp> P; a \<sharp> Q \<rbrakk> \<Longrightarrow> a \<sharp> \<not> P"
+  "a \<sharp> P \<Longrightarrow> a \<sharp> \<not> P"
   by (pred_auto+)
 
 lemma unrest_INF_SUP [unrest]:


### PR DESCRIPTION
Remove an unnecessary assumption from unrest_pred not law.

This is necessary to use the law in e.g. the rea_impl_unrest lemma.