### PR TITLE
Add a bundle no_UTP_lattice_syntax to switch off UTP lattice syntax

### DIFF
--- a/utp_pred.thy
+++ b/utp_pred.thy
@@ -109,7 +109,7 @@ subsection \<open> Lattice syntax \<close>
 
 text \<open> In accordance with \cite{hoare1998}, we turn the lattice operators upside down \<close>
 
-bundle utp_lattice_syntax
+bundle UTP_lattice_syntax
 begin
 
 notation
@@ -128,7 +128,25 @@ syntax
 
 end
 
-unbundle utp_lattice_syntax
+bundle no_UTP_lattice_syntax
+begin
+
+no_notation
+  bot ("\<top>") and
+  top ("\<bottom>") and
+  inf  (infixl "\<squnion>" 70) and
+  sup  (infixl "\<sqinter>" 65) and
+  Inf  ("\<Squnion> _" [900] 900) and
+  Sup  ("\<Sqinter> _" [900] 900)
+
+no_syntax
+  "_INF1"     :: "pttrns \<Rightarrow> 'b \<Rightarrow> 'b"           ("(3\<Squnion>_./ _)" [0, 10] 10)
+  "_INF"      :: "pttrn \<Rightarrow> 'a set \<Rightarrow> 'b \<Rightarrow> 'b"  ("(3\<Squnion>_\<in>_./ _)" [0, 0, 10] 10)
+  "_SUP1"     :: "pttrns \<Rightarrow> 'b \<Rightarrow> 'b"           ("(3\<Sqinter>_./ _)" [0, 10] 10)
+  "_SUP"      :: "pttrn \<Rightarrow> 'a set \<Rightarrow> 'b \<Rightarrow> 'b"  ("(3\<Sqinter>_\<in>_./ _)" [0, 0, 10] 10)
+end
+
+unbundle UTP_lattice_syntax
 
 subsection \<open> Substitution Laws \<close>
 


### PR DESCRIPTION
In my mechanisation, I don't need lattice syntax from UTP and would use the lattice syntax from Isabelle HOL. For this reason, I have added a bundle no_UTP_lattice_syntax to switch off UTP lattice syntax. 

By the way, I change the name utp_lattice_syntax to UTP_lattice_syntax to make its name consistent with other bundle names in UTP, like UTP_Logic_Syntax.

After this update, I have the following commands at the beginning of my theory:

unbundle UTP_Syntax
(* Switch off lattice syntax from UTP *)
unbundle no_UTP_lattice_syntax
(* Switch on lattice syntax from HOL *)
unbundle lattice_syntax